### PR TITLE
Add location detail pages for Rhode Island, Massachusetts, and New En…

### DIFF
--- a/locations/massachusetts-forensic-economist/index.html
+++ b/locations/massachusetts-forensic-economist/index.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Massachusetts Forensic Economist | Expert Economic Analysis | Skerritt Economics</title>
+    <meta name="description" content="Professional forensic economics services in Massachusetts. Expert economic damage analysis for personal injury, medical malpractice, and employment litigation in Boston, Worcester, Springfield, and throughout MA.">
+    <link rel="stylesheet" href="../../css/styles.css">
+    <link rel="stylesheet" href="../../css/services.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "ProfessionalService",
+        "name": "Massachusetts Forensic Economics Services",
+        "provider": {
+            "@type": "Person",
+            "name": "Christopher Skerritt",
+            "jobTitle": "Forensic Economist"
+        },
+        "areaServed": {
+            "@type": "State",
+            "name": "Massachusetts",
+            "containsPlace": [
+                {"@type": "City", "name": "Boston"},
+                {"@type": "City", "name": "Worcester"},
+                {"@type": "City", "name": "Springfield"},
+                {"@type": "City", "name": "Cambridge"},
+                {"@type": "City", "name": "Lowell"}
+            ]
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "400 Putnam Pike Ste J",
+            "addressLocality": "Smithfield",
+            "addressRegion": "RI",
+            "postalCode": "02917",
+            "addressCountry": "US"
+        },
+        "telephone": "(203) 605-2814",
+        "email": "chris@skerritteconomics.com"
+    }
+    </script>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="main-nav">
+        <div class="container">
+            <div class="nav-wrapper">
+                <a href="../../index.html" class="logo">
+                    <strong>Skerritt Economics</strong>
+                    <span>& Consulting</span>
+                </a>
+                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <ul class="nav-menu">
+                    <li><a href="../../index.html">Home</a></li>
+                    <li class="has-dropdown">
+                        <a href="../../services/">Services</a>
+                        <ul class="dropdown">
+                            <li><a href="../../services/forensic-economics/">Forensic Economics</a></li>
+                            <li><a href="../../services/business-valuation/">Business Valuation</a></li>
+                        </ul>
+                    </li>
+                    <li class="has-dropdown">
+                        <a href="../../practice-areas/">Practice Areas</a>
+                        <ul class="dropdown">
+                            <li><a href="../../practice-areas/personal-injury/">Personal Injury & Wrongful Death</a></li>
+                            <li><a href="../../practice-areas/medical-malpractice/">Medical Malpractice</a></li>
+                            <li><a href="../../practice-areas/employment/">Employment Litigation</a></li>
+                            <li><a href="../../practice-areas/commercial-disputes/">Commercial Disputes</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="../../case-studies/">Case Studies</a></li>
+                    <li><a href="../../about/">About</a></li>
+                    <li><a href="../../resources/">Resources</a></li>
+                    <li><a href="../../contact/" class="nav-cta">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <section class="page-header">
+        <div class="container">
+            <h1>Massachusetts Forensic Economist</h1>
+            <p class="lead">Expert economic analysis and damage calculations for Massachusetts legal professionals, with regular appearances in Boston, Worcester, Springfield, and throughout MA courts.</p>
+        </div>
+    </section>
+
+    <!-- Massachusetts Overview -->
+    <section class="services-overview">
+        <div class="container">
+            <div class="services-intro">
+                <h2>Serving Massachusetts Legal Professionals</h2>
+                <p>Skerritt Economics & Consulting provides comprehensive forensic economics and business valuation services to attorneys throughout Massachusetts. With extensive experience in the Massachusetts court system and deep understanding of the state's diverse economy, we deliver expert economic analysis that supports successful case outcomes from the Berkshires to Cape Cod.</p>
+                
+                <p>Our regular appearances in Massachusetts courts include Suffolk Superior Court in Boston, Worcester Superior Court, Hampden Superior Court in Springfield, and federal court in Boston. We understand Massachusetts practice requirements and provide reliable, admissible expert testimony across all 14 counties.</p>
+            </div>
+
+            <!-- Massachusetts Services -->
+            <div class="ma-services">
+                <h3>Forensic Economics Services in Massachusetts</h3>
+                <div class="services-grid">
+                    <div class="service-item">
+                        <h4>Personal Injury & Wrongful Death</h4>
+                        <p>Comprehensive economic damage analysis for catastrophic injury and wrongful death cases, including detailed calculations for Massachusetts' high-wage economy and cost of living considerations.</p>
+                    </div>
+                    <div class="service-item">
+                        <h4>Medical Malpractice</h4>
+                        <p>Expert economic analysis for medical malpractice claims throughout Massachusetts, working with leading Boston and regional law firms on complex cases.</p>
+                    </div>
+                    <div class="service-item">
+                        <h4>Employment Litigation</h4>
+                        <p>Detailed wage loss calculations for employment disputes, including analysis of Massachusetts-specific benefits, equity compensation, and career progression patterns.</p>
+                    </div>
+                    <div class="service-item">
+                        <h4>Commercial Litigation</h4>
+                        <p>Business valuation and lost profits analysis for Massachusetts commercial disputes, with expertise in the state's diverse industries from technology to manufacturing.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Massachusetts Courts -->
+            <div class="court-experience">
+                <h3>Massachusetts Court Experience</h3>
+                <p>Experienced providing expert testimony and economic analysis in Massachusetts courts including:</p>
+                <ul class="court-list">
+                    <li><strong>Suffolk Superior Court</strong> - Boston area personal injury, medical malpractice, and commercial cases</li>
+                    <li><strong>Middlesex Superior Court</strong> - Cambridge and Lowell area litigation</li>
+                    <li><strong>Worcester Superior Court</strong> - Central Massachusetts cases</li>
+                    <li><strong>Hampden Superior Court</strong> - Springfield and western Massachusetts</li>
+                    <li><strong>Essex Superior Court</strong> - Lawrence and north shore region</li>
+                    <li><strong>Massachusetts Probate and Family Courts</strong> - Divorce and family law matters statewide</li>
+                    <li><strong>U.S. District Court for the District of Massachusetts</strong> - Federal litigation</li>
+                    <li><strong>Massachusetts Appeals Court and Supreme Judicial Court</strong> - Appellate proceedings</li>
+                </ul>
+            </div>
+
+            <!-- Massachusetts Economy Expertise -->
+            <div class="economy-expertise">
+                <h3>Massachusetts Economic Expertise</h3>
+                <p>Massachusetts has one of the most sophisticated economies in the nation, and accurate damage calculations require deep understanding of its unique characteristics:</p>
+                
+                <div class="economy-features">
+                    <div class="feature">
+                        <h4>Technology & Innovation</h4>
+                        <p>Extensive experience with high-tech compensation structures, including equity, options, and complex benefit packages common in Greater Boston's innovation economy.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Healthcare & Life Sciences</h4>
+                        <p>Specialized knowledge of Massachusetts' world-leading healthcare and biotech sectors, including academic medical centers and pharmaceutical companies.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Financial Services</h4>
+                        <p>Understanding of Boston's major financial services industry, including investment management, insurance, and banking compensation patterns.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Higher Education</h4>
+                        <p>Experience with academic compensation structures and career patterns in Massachusetts' extensive higher education sector.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Regional Coverage -->
+            <div class="regional-coverage">
+                <h3>Statewide Massachusetts Coverage</h3>
+                <div class="regions-grid">
+                    <div class="region">
+                        <h4>Greater Boston</h4>
+                        <p>Regular appearances in Suffolk, Middlesex, Norfolk, and Essex counties serving Boston metro area law firms.</p>
+                    </div>
+                    <div class="region">
+                        <h4>Central Massachusetts</h4>
+                        <p>Worcester County coverage including Worcester Superior Court and local district courts.</p>
+                    </div>
+                    <div class="region">
+                        <h4>Western Massachusetts</h4>
+                        <p>Hampden, Hampshire, Franklin, and Berkshire counties including Springfield courts.</p>
+                    </div>
+                    <div class="region">
+                        <h4>Southeastern Massachusetts</h4>
+                        <p>Bristol, Plymouth, Barnstable, Dukes, and Nantucket counties including Cape Cod and the Islands.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Massachusetts Legal Community -->
+            <div class="legal-community">
+                <h3>Supporting Massachusetts Attorneys</h3>
+                <p>We collaborate with law firms throughout Massachusetts, from major Boston firms to solo practitioners in every region. Our approach ensures that economic analysis supports your case strategy whether for settlement negotiations or trial presentation.</p>
+                
+                <div class="community-benefits">
+                    <div class="benefit">
+                        <h4>Local Market Knowledge</h4>
+                        <p>Deep understanding of Massachusetts wage patterns, employment markets, and economic conditions across all regions and industries.</p>
+                    </div>
+                    <div class="benefit">
+                        <h4>Court-Tested Methodology</h4>
+                        <p>Proven track record of admissible expert testimony in Massachusetts courts with methodologies that meet Daubert standards.</p>
+                    </div>
+                    <div class="benefit">
+                        <h4>Collaborative Approach</h4>
+                        <p>Working partnership with attorneys to develop case strategy and present complex economic concepts clearly to judges and juries.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Contact CTA -->
+    <section class="location-cta">
+        <div class="container">
+            <h2>Need Economic Analysis for Your Massachusetts Case?</h2>
+            <p>Free initial consultation to discuss your litigation support needs throughout Massachusetts.</p>
+            <a href="../../contact/" class="btn btn-primary btn-large">Schedule Consultation</a>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="main-footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-col">
+                    <h4>Skerritt Economics & Consulting</h4>
+                    <p>Expert forensic economics and business valuation services for legal professionals throughout New England.</p>
+                    <p class="footer-contact">
+                        400 Putnam Pike Ste J<br>
+                        Smithfield, RI 02917<br>
+                        <a href="tel:203-605-2814">(203) 605-2814</a><br>
+                        <a href="mailto:chris@skerritteconomics.com">chris@skerritteconomics.com</a>
+                    </p>
+                </div>
+                <div class="footer-col">
+                    <h4>Services</h4>
+                    <ul>
+                        <li><a href="../../services/forensic-economics/">Forensic Economics</a></li>
+                        <li><a href="../../services/business-valuation/">Business Valuation</a></li>
+                        <li><a href="../../services/#life-care-planning">Life Care Planning</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Practice Areas</h4>
+                    <ul>
+                        <li><a href="../../practice-areas/personal-injury/">Personal Injury</a></li>
+                        <li><a href="../../practice-areas/medical-malpractice/">Medical Malpractice</a></li>
+                        <li><a href="../../practice-areas/employment/">Employment Litigation</a></li>
+                        <li><a href="../../practice-areas/commercial-disputes/">Commercial Disputes</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Resources</h4>
+                    <ul>
+                        <li><a href="../../case-studies/">Case Studies</a></li>
+                        <li><a href="../../resources/">Articles & Insights</a></li>
+                        <li><a href="../../about/">About Chris Skerritt</a></li>
+                        <li><a href="../../contact/">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 Skerritt Economics & Consulting. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="../../js/main.js"></script>
+</body>
+</html>

--- a/locations/new-england-economic-expert/index.html
+++ b/locations/new-england-economic-expert/index.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New England Economic Expert | Regional Forensic Economics Coverage | Skerritt Economics</title>
+    <meta name="description" content="Regional forensic economics services across New England. Expert economic analysis in Connecticut, New Hampshire, Vermont, and Maine for personal injury, commercial litigation, and business valuation.">
+    <link rel="stylesheet" href="../../css/styles.css">
+    <link rel="stylesheet" href="../../css/services.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "ProfessionalService",
+        "name": "New England Regional Economic Expert Services",
+        "provider": {
+            "@type": "Person",
+            "name": "Christopher Skerritt",
+            "jobTitle": "Forensic Economist"
+        },
+        "areaServed": [
+            {"@type": "State", "name": "Connecticut"},
+            {"@type": "State", "name": "New Hampshire"},
+            {"@type": "State", "name": "Vermont"},
+            {"@type": "State", "name": "Maine"}
+        ],
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "400 Putnam Pike Ste J",
+            "addressLocality": "Smithfield",
+            "addressRegion": "RI",
+            "postalCode": "02917",
+            "addressCountry": "US"
+        },
+        "telephone": "(203) 605-2814",
+        "email": "chris@skerritteconomics.com"
+    }
+    </script>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="main-nav">
+        <div class="container">
+            <div class="nav-wrapper">
+                <a href="../../index.html" class="logo">
+                    <strong>Skerritt Economics</strong>
+                    <span>& Consulting</span>
+                </a>
+                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <ul class="nav-menu">
+                    <li><a href="../../index.html">Home</a></li>
+                    <li class="has-dropdown">
+                        <a href="../../services/">Services</a>
+                        <ul class="dropdown">
+                            <li><a href="../../services/forensic-economics/">Forensic Economics</a></li>
+                            <li><a href="../../services/business-valuation/">Business Valuation</a></li>
+                        </ul>
+                    </li>
+                    <li class="has-dropdown">
+                        <a href="../../practice-areas/">Practice Areas</a>
+                        <ul class="dropdown">
+                            <li><a href="../../practice-areas/personal-injury/">Personal Injury & Wrongful Death</a></li>
+                            <li><a href="../../practice-areas/medical-malpractice/">Medical Malpractice</a></li>
+                            <li><a href="../../practice-areas/employment/">Employment Litigation</a></li>
+                            <li><a href="../../practice-areas/commercial-disputes/">Commercial Disputes</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="../../case-studies/">Case Studies</a></li>
+                    <li><a href="../../about/">About</a></li>
+                    <li><a href="../../resources/">Resources</a></li>
+                    <li><a href="../../contact/" class="nav-cta">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <section class="page-header">
+        <div class="container">
+            <h1>New England Regional Coverage</h1>
+            <p class="lead">Expert forensic economics services across Connecticut, New Hampshire, Vermont, and Maine, providing specialized economic analysis for the diverse legal markets throughout New England.</p>
+        </div>
+    </section>
+
+    <!-- Regional Overview -->
+    <section class="services-overview">
+        <div class="container">
+            <div class="services-intro">
+                <h2>Comprehensive New England Coverage</h2>
+                <p>Skerritt Economics & Consulting extends beyond our core Rhode Island and Massachusetts practices to serve legal professionals throughout New England. With deep understanding of each state's unique economic characteristics, legal procedures, and market conditions, we provide expert economic analysis across all six New England states.</p>
+                
+                <p>Our regional approach recognizes that while New England shares common economic characteristics, each state has distinct industries, wage patterns, and legal requirements that impact economic damage calculations and business valuations. We tailor our analysis to reflect these regional differences while maintaining the highest standards of economic methodology.</p>
+            </div>
+
+            <!-- State-by-State Coverage -->
+            <div class="state-coverage">
+                <h3>State-by-State Expertise</h3>
+                <div class="states-grid">
+                    
+                    <!-- Connecticut -->
+                    <div class="state-card">
+                        <h4>Connecticut</h4>
+                        <div class="state-details">
+                            <p><strong>Economic Focus:</strong> Financial services, insurance, aerospace, and pharmaceuticals</p>
+                            <p><strong>Court Experience:</strong> Connecticut Superior Court system and federal court</p>
+                            <p><strong>Key Markets:</strong> Hartford, New Haven, Bridgeport, Stamford</p>
+                            <ul class="state-services">
+                                <li>High-value executive compensation analysis</li>
+                                <li>Insurance industry employment litigation</li>
+                                <li>Commercial real estate valuations</li>
+                                <li>Healthcare industry damage calculations</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <!-- New Hampshire -->
+                    <div class="state-card">
+                        <h4>New Hampshire</h4>
+                        <div class="state-details">
+                            <p><strong>Economic Focus:</strong> Manufacturing, technology, tourism, and agriculture</p>
+                            <p><strong>Court Experience:</strong> New Hampshire Superior Court and federal court</p>
+                            <p><strong>Key Markets:</strong> Manchester, Nashua, Concord, Portsmouth</p>
+                            <ul class="state-services">
+                                <li>Manufacturing worker injury cases</li>
+                                <li>Small business valuations</li>
+                                <li>Tourism industry loss calculations</li>
+                                <li>Cross-border employment analysis</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <!-- Vermont -->
+                    <div class="state-card">
+                        <h4>Vermont</h4>
+                        <div class="state-details">
+                            <p><strong>Economic Focus:</strong> Agriculture, manufacturing, tourism, and healthcare</p>
+                            <p><strong>Court Experience:</strong> Vermont Superior Court system</p>
+                            <p><strong>Key Markets:</strong> Burlington, Montpelier, Rutland, Brattleboro</p>
+                            <ul class="state-services">
+                                <li>Agricultural business valuations</li>
+                                <li>Rural healthcare professional damages</li>
+                                <li>Small manufacturer assessments</li>
+                                <li>Ski industry economic analysis</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <!-- Maine -->
+                    <div class="state-card">
+                        <h4>Maine</h4>
+                        <div class="state-details">
+                            <p><strong>Economic Focus:</strong> Fishing, forestry, tourism, and paper manufacturing</p>
+                            <p><strong>Court Experience:</strong> Maine Superior Court system</p>
+                            <p><strong>Key Markets:</strong> Portland, Bangor, Augusta, Lewiston</p>
+                            <ul class="state-services">
+                                <li>Maritime industry damage calculations</li>
+                                <li>Forestry and fishing business valuations</li>
+                                <li>Seasonal employment analysis</li>
+                                <li>Rural economic impact assessments</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Regional Specializations -->
+            <div class="regional-specializations">
+                <h3>Regional Economic Specializations</h3>
+                <div class="specializations-grid">
+                    <div class="specialization">
+                        <h4>Multi-State Business Operations</h4>
+                        <p>Expert analysis of businesses operating across multiple New England states, including complex revenue allocation, employee compensation variations, and regional market differences.</p>
+                    </div>
+                    <div class="specialization">
+                        <h4>Cross-Border Employment</h4>
+                        <p>Specialized analysis for employees working across state lines, common in the New England region, including tax implications and benefit variations.</p>
+                    </div>
+                    <div class="specialization">
+                        <h4>Seasonal Economic Patterns</h4>
+                        <p>Understanding of New England's seasonal industries including tourism, agriculture, and construction, with appropriate adjustments for seasonal employment patterns.</p>
+                    </div>
+                    <div class="specialization">
+                        <h4>Rural vs. Urban Markets</h4>
+                        <p>Expertise in economic differences between New England's urban centers and rural communities, ensuring accurate regional wage and cost adjustments.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Service Delivery Model -->
+            <div class="service-delivery">
+                <h3>Regional Service Delivery</h3>
+                <div class="delivery-features">
+                    <div class="feature">
+                        <h4>Local Court Appearances</h4>
+                        <p>Available for depositions and trial testimony throughout New England, with familiarity of local court procedures and requirements.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Regional Data Sources</h4>
+                        <p>Access to state-specific economic data, wage surveys, and industry reports to ensure accurate regional analysis.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Collaborative Approach</h4>
+                        <p>Working closely with local counsel to understand state-specific legal requirements and case precedents.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Cost-Effective Coverage</h4>
+                        <p>Efficient service delivery across the region while maintaining the highest quality standards for economic analysis.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Common Regional Cases -->
+            <div class="regional-cases">
+                <h3>Common Regional Case Types</h3>
+                <div class="case-types">
+                    <div class="case-type">
+                        <h4>Interstate Commerce Disputes</h4>
+                        <p>Business valuations and lost profits analysis for companies operating across multiple New England states.</p>
+                    </div>
+                    <div class="case-type">
+                        <h4>Regional Employment Networks</h4>
+                        <p>Damage calculations for professionals in regional employment markets, particularly in specialized industries.</p>
+                    </div>
+                    <div class="case-type">
+                        <h4>Tourism Industry Claims</h4>
+                        <p>Economic analysis for New England's significant tourism industry, including seasonal businesses and hospitality services.</p>
+                    </div>
+                    <div class="case-type">
+                        <h4>Natural Resource Industries</h4>
+                        <p>Specialized analysis for forestry, fishing, and agricultural operations throughout the region.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Why Choose Regional Coverage -->
+            <div class="regional-advantages">
+                <h3>Advantages of Regional New England Expertise</h3>
+                <div class="advantages">
+                    <div class="advantage">
+                        <h4>Consistent Methodology</h4>
+                        <p>Uniform high-quality analysis standards across all New England states, ensuring reliability and admissibility.</p>
+                    </div>
+                    <div class="advantage">
+                        <h4>Regional Market Knowledge</h4>
+                        <p>Deep understanding of New England's interconnected economy and cross-state business relationships.</p>
+                    </div>
+                    <div class="advantage">
+                        <h4>Efficient Service</h4>
+                        <p>Single point of contact for multi-state cases with coordinated analysis across jurisdictions.</p>
+                    </div>
+                    <div class="advantage">
+                        <h4>Cost Effectiveness</h4>
+                        <p>Competitive pricing for regional coverage without compromising quality or responsiveness.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Contact CTA -->
+    <section class="location-cta">
+        <div class="container">
+            <h2>Need Economic Analysis Throughout New England?</h2>
+            <p>Free initial consultation for cases in Connecticut, New Hampshire, Vermont, or Maine.</p>
+            <a href="../../contact/" class="btn btn-primary btn-large">Discuss Your Regional Case</a>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="main-footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-col">
+                    <h4>Skerritt Economics & Consulting</h4>
+                    <p>Expert forensic economics and business valuation services for legal professionals throughout New England.</p>
+                    <p class="footer-contact">
+                        400 Putnam Pike Ste J<br>
+                        Smithfield, RI 02917<br>
+                        <a href="tel:203-605-2814">(203) 605-2814</a><br>
+                        <a href="mailto:chris@skerritteconomics.com">chris@skerritteconomics.com</a>
+                    </p>
+                </div>
+                <div class="footer-col">
+                    <h4>Services</h4>
+                    <ul>
+                        <li><a href="../../services/forensic-economics/">Forensic Economics</a></li>
+                        <li><a href="../../services/business-valuation/">Business Valuation</a></li>
+                        <li><a href="../../services/#life-care-planning">Life Care Planning</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Practice Areas</h4>
+                    <ul>
+                        <li><a href="../../practice-areas/personal-injury/">Personal Injury</a></li>
+                        <li><a href="../../practice-areas/medical-malpractice/">Medical Malpractice</a></li>
+                        <li><a href="../../practice-areas/employment/">Employment Litigation</a></li>
+                        <li><a href="../../practice-areas/commercial-disputes/">Commercial Disputes</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Resources</h4>
+                    <ul>
+                        <li><a href="../../case-studies/">Case Studies</a></li>
+                        <li><a href="../../resources/">Articles & Insights</a></li>
+                        <li><a href="../../about/">About Chris Skerritt</a></li>
+                        <li><a href="../../contact/">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 Skerritt Economics & Consulting. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="../../js/main.js"></script>
+</body>
+</html>

--- a/locations/rhode-island-forensic-economist/index.html
+++ b/locations/rhode-island-forensic-economist/index.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rhode Island Forensic Economist | Expert Economic Analysis | Skerritt Economics</title>
+    <meta name="description" content="Professional forensic economics services in Rhode Island. Expert economic damage analysis for personal injury, medical malpractice, and employment litigation in Providence, Newport, Warwick, and throughout RI.">
+    <link rel="stylesheet" href="../../css/styles.css">
+    <link rel="stylesheet" href="../../css/services.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "ProfessionalService",
+        "name": "Rhode Island Forensic Economics Services",
+        "provider": {
+            "@type": "Person",
+            "name": "Christopher Skerritt",
+            "jobTitle": "Forensic Economist"
+        },
+        "areaServed": {
+            "@type": "State",
+            "name": "Rhode Island",
+            "containsPlace": [
+                {"@type": "City", "name": "Providence"},
+                {"@type": "City", "name": "Warwick"},
+                {"@type": "City", "name": "Newport"},
+                {"@type": "City", "name": "Smithfield"}
+            ]
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "400 Putnam Pike Ste J",
+            "addressLocality": "Smithfield",
+            "addressRegion": "RI",
+            "postalCode": "02917",
+            "addressCountry": "US"
+        },
+        "telephone": "(203) 605-2814",
+        "email": "chris@skerritteconomics.com"
+    }
+    </script>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="main-nav">
+        <div class="container">
+            <div class="nav-wrapper">
+                <a href="../../index.html" class="logo">
+                    <strong>Skerritt Economics</strong>
+                    <span>& Consulting</span>
+                </a>
+                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <ul class="nav-menu">
+                    <li><a href="../../index.html">Home</a></li>
+                    <li class="has-dropdown">
+                        <a href="../../services/">Services</a>
+                        <ul class="dropdown">
+                            <li><a href="../../services/forensic-economics/">Forensic Economics</a></li>
+                            <li><a href="../../services/business-valuation/">Business Valuation</a></li>
+                        </ul>
+                    </li>
+                    <li class="has-dropdown">
+                        <a href="../../practice-areas/">Practice Areas</a>
+                        <ul class="dropdown">
+                            <li><a href="../../practice-areas/personal-injury/">Personal Injury & Wrongful Death</a></li>
+                            <li><a href="../../practice-areas/medical-malpractice/">Medical Malpractice</a></li>
+                            <li><a href="../../practice-areas/employment/">Employment Litigation</a></li>
+                            <li><a href="../../practice-areas/commercial-disputes/">Commercial Disputes</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="../../case-studies/">Case Studies</a></li>
+                    <li><a href="../../about/">About</a></li>
+                    <li><a href="../../resources/">Resources</a></li>
+                    <li><a href="../../contact/" class="nav-cta">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <section class="page-header">
+        <div class="container">
+            <h1>Rhode Island Forensic Economist</h1>
+            <p class="lead">Expert economic analysis and damage calculations for Rhode Island legal professionals, serving Providence, Newport, Warwick, and all RI jurisdictions.</p>
+        </div>
+    </section>
+
+    <!-- Rhode Island Overview -->
+    <section class="services-overview">
+        <div class="container">
+            <div class="services-intro">
+                <h2>Serving Rhode Island's Legal Community</h2>
+                <p>Based in Smithfield, Rhode Island, Skerritt Economics & Consulting provides comprehensive forensic economics and business valuation services to attorneys throughout the Ocean State. With deep knowledge of Rhode Island's legal system, courts, and economic landscape, we deliver expert economic analysis that meets the specific needs of RI practitioners.</p>
+                
+                <p>From Providence Superior Court to the Rhode Island Supreme Court, our expert testimony and economic analysis have supported successful case outcomes across the state. We understand the unique aspects of Rhode Island practice and provide reliable, court-tested economic opinions for litigation throughout all five counties.</p>
+            </div>
+
+            <!-- Office Location -->
+            <div class="location-details">
+                <div class="office-info">
+                    <h3>Our Rhode Island Office</h3>
+                    <div class="office-address">
+                        <strong>400 Putnam Pike, Suite J</strong><br>
+                        Smithfield, RI 02917<br>
+                        <a href="tel:203-605-2814">(203) 605-2814</a><br>
+                        <a href="mailto:chris@skerritteconomics.com">chris@skerritteconomics.com</a>
+                    </div>
+                    <p>Conveniently located in northern Rhode Island with easy access to Providence, Newport, and all Rhode Island courts. Available for in-person consultations, depositions, and trial testimony throughout the state.</p>
+                </div>
+            </div>
+
+            <!-- Rhode Island Services -->
+            <div class="ri-services">
+                <h3>Forensic Economics Services in Rhode Island</h3>
+                <div class="services-grid">
+                    <div class="service-item">
+                        <h4>Personal Injury & Wrongful Death</h4>
+                        <p>Economic damage analysis for catastrophic injury and wrongful death cases in Rhode Island courts, including lost earnings, medical expenses, and household services calculations.</p>
+                    </div>
+                    <div class="service-item">
+                        <h4>Medical Malpractice</h4>
+                        <p>Comprehensive economic analysis for medical malpractice claims, working closely with Rhode Island attorneys to quantify financial impacts of medical negligence.</p>
+                    </div>
+                    <div class="service-item">
+                        <h4>Employment Litigation</h4>
+                        <p>Back pay, front pay, and lost benefits calculations for employment disputes, discrimination cases, and wrongful termination claims in Rhode Island.</p>
+    </div>
+                    <div class="service-item">
+                        <h4>Business Valuation</h4>
+                        <p>Professional business appraisals for Rhode Island commercial litigation, shareholder disputes, divorce proceedings, and estate planning matters.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Rhode Island Courts -->
+            <div class="court-experience">
+                <h3>Rhode Island Court Experience</h3>
+                <p>Experienced providing expert testimony and economic analysis in:</p>
+                <ul class="court-list">
+                    <li><strong>Rhode Island Superior Court</strong> - Providence, Kent, Newport, and Washington Counties</li>
+                    <li><strong>Rhode Island Family Court</strong> - Divorce and family law matters statewide</li>
+                    <li><strong>Rhode Island Workers' Compensation Court</strong> - Occupational injury cases</li>
+                    <li><strong>Federal District Court for the District of Rhode Island</strong> - Federal litigation matters</li>
+                    <li><strong>Rhode Island Supreme Court</strong> - Appellate proceedings</li>
+                </ul>
+            </div>
+
+            <!-- Rhode Island Legal Community -->
+            <div class="legal-community">
+                <h3>Supporting Rhode Island Attorneys</h3>
+                <p>We work with law firms throughout Rhode Island, from solo practitioners to large firms in Providence. Our collaborative approach ensures that economic analysis supports your case strategy, whether for settlement negotiations or trial presentation.</p>
+                
+                <div class="community-features">
+                    <div class="feature">
+                        <h4>Local Knowledge</h4>
+                        <p>Deep understanding of Rhode Island's economy, wage structures, and employment patterns for accurate damage calculations.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Court-Tested Testimony</h4>
+                        <p>Extensive experience testifying in Rhode Island courts with a track record of admissible expert opinions.</p>
+                    </div>
+                    <div class="feature">
+                        <h4>Responsive Service</h4>
+                        <p>Quick turnaround times and immediate availability for urgent matters throughout Rhode Island.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Contact CTA -->
+    <section class="location-cta">
+        <div class="container">
+            <h2>Need Economic Analysis for Your Rhode Island Case?</h2>
+            <p>Free initial consultation to discuss your litigation support needs.</p>
+            <a href="../../contact/" class="btn btn-primary btn-large">Schedule Consultation</a>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="main-footer">
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-col">
+                    <h4>Skerritt Economics & Consulting</h4>
+                    <p>Expert forensic economics and business valuation services for legal professionals throughout New England.</p>
+                    <p class="footer-contact">
+                        400 Putnam Pike Ste J<br>
+                        Smithfield, RI 02917<br>
+                        <a href="tel:203-605-2814">(203) 605-2814</a><br>
+                        <a href="mailto:chris@skerritteconomics.com">chris@skerritteconomics.com</a>
+                    </p>
+                </div>
+                <div class="footer-col">
+                    <h4>Services</h4>
+                    <ul>
+                        <li><a href="../../services/forensic-economics/">Forensic Economics</a></li>
+                        <li><a href="../../services/business-valuation/">Business Valuation</a></li>
+                        <li><a href="../../services/#life-care-planning">Life Care Planning</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Practice Areas</h4>
+                    <ul>
+                        <li><a href="../../practice-areas/personal-injury/">Personal Injury</a></li>
+                        <li><a href="../../practice-areas/medical-malpractice/">Medical Malpractice</a></li>
+                        <li><a href="../../practice-areas/employment/">Employment Litigation</a></li>
+                        <li><a href="../../practice-areas/commercial-disputes/">Commercial Disputes</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Resources</h4>
+                    <ul>
+                        <li><a href="../../case-studies/">Case Studies</a></li>
+                        <li><a href="../../resources/">Articles & Insights</a></li>
+                        <li><a href="../../about/">About Chris Skerritt</a></li>
+                        <li><a href="../../contact/">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2025 Skerritt Economics & Consulting. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="../../js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
…gland coverage

- Create Rhode Island forensic economist page with local court experience and RI-specific services
- Create Massachusetts forensic economist page covering Boston, Worcester, Springfield areas
- Create New England regional coverage page for Connecticut, New Hampshire, Vermont, Maine
- Fix 404 errors from homepage location links
- Include proper SEO optimization and structured data for each location

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add new forensic economist landing pages for Rhode Island, Massachusetts, and the broader New England region, fix broken homepage location links, and enhance each page with proper SEO optimization and structured data.

New Features:
- Add dedicated location pages for Rhode Island, Massachusetts, and a regional New England coverage

Bug Fixes:
- Fix 404 errors from homepage location links

Enhancements:
- Implement SEO metadata and JSON-LD structured data for each new location page