### PR TITLE
Add canonical links for MA, New England, RI pages

### DIFF
--- a/locations/massachusetts-forensic-economist/index.html
+++ b/locations/massachusetts-forensic-economist/index.html
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="canonical" href="https://skerritteconomics.com/locations/massachusetts-forensic-economist/">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/locations/new-england-economic-expert/index.html
+++ b/locations/new-england-economic-expert/index.html
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="canonical" href="https://skerritteconomics.com/locations/new-england-economic-expert/">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/locations/rhode-island-forensic-economist/index.html
+++ b/locations/rhode-island-forensic-economist/index.html
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="canonical" href="https://skerritteconomics.com/locations/rhode-island-forensic-economist/">
     
     <!-- Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- add canonical link tags to Massachusetts, New England, and Rhode Island location pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f577486f4832fb9999f161d5ed347

## Summary by Sourcery

Add canonical link tags to Massachusetts, New England, and Rhode Island location pages to consolidate SEO and prevent duplicate content issues.

Enhancements:
- Add canonical link tag to the Massachusetts forensic economist page
- Add canonical link tag to the New England economic expert page
- Add canonical link tag to the Rhode Island forensic economist page