### PR TITLE
Improve accessibility with skip links and ARIA

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -221,20 +221,24 @@
 }</script>
 </head>
 <body>
+<!-- Skip Navigation Links -->
+<a href="#main-content" class="skip-nav">Skip to main content</a>
+<a href="#main-navigation" class="skip-nav">Skip to navigation</a>
+<a href="#footer" class="skip-nav">Skip to footer</a>
 <!-- Navigation -->
-<nav class="main-nav">
+<nav class="main-nav" id="main-navigation" role="navigation" aria-label="Primary">
 <div class="container">
 <div class="nav-wrapper">
 <a class="logo" href="../index.html">
 <strong>Skerritt Economics</strong>
 <span>&amp; Consulting</span>
 </a>
-<button aria-label="Toggle menu" class="mobile-menu-toggle">
+<button aria-label="Toggle menu" class="mobile-menu-toggle" aria-controls="primary-navigation" aria-expanded="false">
 <span></span>
 <span></span>
 <span></span>
 </button>
-<ul class="nav-menu">
+<ul class="nav-menu" id="primary-navigation">
 <li><a href="../index.html">Home</a></li>
 <li class="has-dropdown">
 <a href="../services/">Services</a>
@@ -276,6 +280,7 @@
 </ol>
 </div>
 </nav>
+<main id="main-content" tabindex="-1">
 <!-- About Hero -->
 <section class="about-hero">
 <div class="container">
@@ -489,6 +494,7 @@
 </div>
 </div>
 </section>
+</main>
 <!-- Footer -->
 <footer class="main-footer">
 <div class="container">

--- a/contact/index.html
+++ b/contact/index.html
@@ -106,20 +106,23 @@
 }</script>
 </head>
 <body>
-<!-- Navigation -->
-<nav class="main-nav">
+<!-- Skip Navigation Links -->
+<a href="#main-content" class="skip-nav">Skip to main content</a>
+<a href="#main-navigation" class="skip-nav">Skip to navigation</a>
+<a href="#footer" class="skip-nav">Skip to footer</a>
+<nav class="main-nav" id="main-navigation" role="navigation" aria-label="Primary">
 <div class="container">
 <div class="nav-wrapper">
 <a class="logo" href="../index.html">
 <strong>Skerritt Economics</strong>
 <span>&amp; Consulting</span>
 </a>
-<button aria-label="Toggle menu" class="mobile-menu-toggle">
+<button aria-label="Toggle menu" class="mobile-menu-toggle" aria-controls="primary-navigation" aria-expanded="false">
 <span></span>
 <span></span>
 <span></span>
 </button>
-<ul class="nav-menu">
+<ul class="nav-menu" id="primary-navigation">
 <li><a href="../index.html">Home</a></li>
 <li class="has-dropdown">
 <a href="../services/">Services</a>
@@ -160,6 +163,7 @@
 </ol>
 </div>
 </nav>
+<main id="main-content" tabindex="-1">
 <!-- Contact Header -->
 <section class="contact-header">
 <div class="container">
@@ -432,6 +436,7 @@
 </div>
 </div>
 </section>
+</main>
 <!-- Footer -->
 <footer class="main-footer">
 <div class="container">

--- a/contact/thank-you/index.html
+++ b/contact/thank-you/index.html
@@ -108,19 +108,23 @@
 </head>
 <body>
     <!-- Navigation -->
-    <nav class="main-nav">
+<!-- Skip Navigation Links -->
+<a href="#main-content" class="skip-nav">Skip to main content</a>
+<a href="#main-navigation" class="skip-nav">Skip to navigation</a>
+<a href="#footer" class="skip-nav">Skip to footer</a>
+    <nav class="main-nav" id="main-navigation" role="navigation" aria-label="Primary">
         <div class="container">
             <div class="nav-wrapper">
                 <a href="../../index.html" class="logo">
                     <strong>Skerritt Economics</strong>
                     <span>& Consulting</span>
                 </a>
-                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                <button class="mobile-menu-toggle" aria-label="Toggle menu" aria-controls="primary-navigation" aria-expanded="false">
                     <span></span>
                     <span></span>
                     <span></span>
                 </button>
-                <ul class="nav-menu">
+                <ul class="nav-menu" id="primary-navigation">
                     <li><a href="../../index.html">Home</a></li>
                     <li class="has-dropdown">
                         <a href="../../services/">Services</a>
@@ -146,7 +150,7 @@
             </div>
         </div>
     </nav>
-
+<main id="main-content" tabindex="-1">
     <!-- Thank You Section -->
     <section class="thank-you-section">
         <div class="container">
@@ -174,7 +178,7 @@
             </div>
         </div>
     </section>
-
+</main>
     <!-- Footer -->
     <footer class="main-footer">
         <div class="container">

--- a/index.html
+++ b/index.html
@@ -441,19 +441,19 @@
 <a href="#main-navigation" class="skip-nav">Skip to navigation</a>
 <a href="#footer" class="skip-nav">Skip to footer</a>
 <!-- Navigation -->
-<nav class="main-nav" id="main-navigation">
+<nav class="main-nav" id="main-navigation" role="navigation" aria-label="Primary">
 <div class="container">
 <div class="nav-wrapper">
 <a class="logo" href="index.html">
 <strong>Skerritt Economics</strong>
 <span>&amp; Consulting</span>
 </a>
-<button aria-label="Toggle menu" class="mobile-menu-toggle">
+<button aria-label="Toggle menu" class="mobile-menu-toggle" aria-controls="primary-navigation" aria-expanded="false">
 <span></span>
 <span></span>
 <span></span>
 </button>
-<ul class="nav-menu">
+<ul class="nav-menu" id="primary-navigation">
 <li><a href="index.html">Home</a></li>
 <li class="has-dropdown">
 <a href="services/">Services</a>
@@ -483,7 +483,8 @@
 </div>
 </nav>
 <!-- Hero Section -->
-<section class="hero" id="main-content">
+<main id="main-content" tabindex="-1">
+<section class="hero">
 <div class="container">
 <div class="hero-content">
 <h1>Forensic Economics and Business Valuations</h1>
@@ -853,6 +854,7 @@ Email: <a href="mailto:chris@skerritteconomics.com" onclick="trackEmailClick()">
 </div>
 </div>
 </section>
+</main>
 <!-- Footer -->
 <footer class="main-footer" id="footer">
 <div class="container">

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,8 @@ document.addEventListener('DOMContentLoaded', function() {
             navMenu.classList.toggle('active');
             mobileNavOverlay.classList.toggle('active');
             this.classList.toggle('active');
+            const expanded = this.getAttribute("aria-expanded") === "true";
+            this.setAttribute("aria-expanded", !expanded);
             document.body.classList.toggle('menu-open');
         });
     }
@@ -42,6 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (navMenu) navMenu.classList.remove('active');
                 if (mobileNavOverlay) mobileNavOverlay.classList.remove('active');
                 if (mobileMenuToggle) mobileMenuToggle.classList.remove('active');
+                if (mobileMenuToggle) mobileMenuToggle.setAttribute("aria-expanded","false");
                 document.body.classList.remove('menu-open');
             }
         });
@@ -51,6 +54,7 @@ document.addEventListener('DOMContentLoaded', function() {
     mobileNavOverlay.addEventListener('click', function() {
         if (navMenu) navMenu.classList.remove('active');
         if (mobileNavOverlay) mobileNavOverlay.classList.remove('active');
+        if (mobileMenuToggle) mobileMenuToggle.setAttribute("aria-expanded","false");
         if (mobileMenuToggle) mobileMenuToggle.classList.remove('active');
         document.body.classList.remove('menu-open');
     });
@@ -61,6 +65,7 @@ document.addEventListener('DOMContentLoaded', function() {
             navMenu.classList.remove('active');
             mobileNavOverlay.classList.remove('active');
             mobileMenuToggle.classList.remove('active');
+            mobileMenuToggle.setAttribute("aria-expanded","false");
             document.body.classList.remove('menu-open');
         }
     });


### PR DESCRIPTION
## Summary
- add skip navigation links on all main pages
- mark navigation with ARIA roles and controls
- wrap page contents in `<main>` for better screen reader support
- toggle `aria-expanded` in the mobile menu script

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aa90798a8832fa2b6d8bc69edff80

## Summary by Sourcery

Improve accessibility across the site by introducing skip links, semantic <main> landmarks, ARIA roles and labels for navigation, and dynamic aria-expanded handling in the mobile menu script

New Features:
- Add skip navigation links to jump to main content, navigation, and footer on all main pages

Enhancements:
- Wrap page content in <main> elements with tabindex for better screen reader support
- Annotate primary navigation with role="navigation" and aria-label attributes
- Assign aria-controls and initial aria-expanded attributes to mobile menu toggle buttons