### PR TITLE
Remove duplicate preconnect for fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,8 +445,6 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
         }
     }
     </script>
-<!-- Performance hint for Google fonts -->
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
 <meta name="author" content="Chris Skerritt">
 <meta name="geo.region" content="US-RI">


### PR DESCRIPTION
## Summary
- cleaned up extra `fonts.gstatic.com` preconnect in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad6946478832f93cb0aa03e000f44

## Summary by Sourcery

Enhancements:
- Eliminate duplicate fonts.gstatic.com preconnect tag in index.html