### PR TITLE
Remove header margin and TOC placeholder

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1426,6 +1426,17 @@ body {
     line-height: 1.6;
     color: var(--dark-text);
     background-color: var(--background);
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.table-of-contents {
+    display: none;
 }
 
 .container {

--- a/css/styles.min.css
+++ b/css/styles.min.css
@@ -1426,6 +1426,17 @@ body {
     line-height: 1.6;
     color: var(--dark-text);
     background-color: var(--background);
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.table-of-contents {
+    display: none;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- ensure body and header start flush at top of page
- hide unused table-of-contents element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ae1aa834c832f829d11fe707598e9

## Summary by Sourcery

Remove default spacing on the page header and body, and disable the table-of-contents placeholder.

Enhancements:
- Reset margin and padding on the body and header to ensure content starts flush at the top
- Hide the unused table-of-contents element by setting it to display: none