### PR TITLE
Fix XX state code placeholders in location pages

### DIFF
--- a/locations/cities/columbus-ga-ga-life-care-planner.html
+++ b/locations/cities/columbus-ga-ga-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Columbus GA Life Care Planner | GA Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Columbus GA. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Columbus GA attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner columbus ga, life care planning XX, future medical costs columbus ga, catastrophic injury expert Columbus GA, CLCP certified columbus ga, medical cost projections, life care plan columbus ga, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner columbus ga, life care planning GA, future medical costs columbus ga, catastrophic injury expert Columbus GA, CLCP certified columbus ga, medical cost projections, life care plan columbus ga, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/columbus-ga-ga-life-care-planner.html" rel="canonical"/>
     <meta content="Columbus GA Life Care Planner | GA Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Columbus GA, XX - Life Care Planner",
+                "name": "Columbus GA, Georgia - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/columbus-ga-ga-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Columbus GA Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Columbus GA and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Columbus GA and Georgia.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Columbus GA, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Columbus GA, Georgia - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through Georgia pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet Georgia court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>Georgia Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Columbus GA, XX
+                                Serving Columbus GA, GA
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Columbus GA</h3>
                         <ul class="service-links">
-                            <li><a href="columbus-ga-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="columbus-ga-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="columbus-ga-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="columbus-ga-ga-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="columbus-ga-ga-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="columbus-ga-ga-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Columbus, Georgia Coverage Area</h3>
-                        <p>In addition to Columbus GA, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Columbus GA, we serve attorneys throughout Georgia including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout Georgia and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/columbus-ga-ga-vocational-expert.html
+++ b/locations/cities/columbus-ga-ga-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Columbus GA Vocational Expert | GA Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Columbus GA. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Columbus GA attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert columbus ga, vocational expert XX, earning capacity expert columbus ga, employability assessment Columbus GA, expert witness vocational, litigation support columbus ga, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert columbus ga, vocational expert GA, earning capacity expert columbus ga, employability assessment Columbus GA, expert witness vocational, litigation support columbus ga, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/columbus-ga-ga-vocational-expert.html" rel="canonical"/>
     <meta content="Columbus GA Vocational Expert | GA Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Columbus GA, XX - Vocational Expert",
+                "name": "Columbus GA, Georgia - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/columbus-ga-ga-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Columbus GA Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Columbus GA and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Columbus GA and Georgia.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Columbus GA, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Columbus GA, Georgia - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for Georgia family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Columbus GA metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>Georgia vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Columbus GA, XX
+                                Serving Columbus GA, GA
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Columbus GA</h3>
                         <ul class="service-links">
-                            <li><a href="columbus-ga-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="columbus-ga-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="columbus-ga-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="columbus-ga-ga-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="columbus-ga-ga-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="columbus-ga-ga-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Columbus, Georgia Coverage Area</h3>
-                        <p>In addition to Columbus GA, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Columbus GA, we serve attorneys throughout Georgia including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout Georgia and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/smyrna-ga-ga-life-care-planner.html
+++ b/locations/cities/smyrna-ga-ga-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Smyrna Life Care Planner | GA Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Smyrna. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Smyrna attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner smyrna ga, life care planning XX, future medical costs smyrna ga, catastrophic injury expert Smyrna, CLCP certified smyrna ga, medical cost projections, life care plan smyrna ga, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner smyrna ga, life care planning GA, future medical costs smyrna ga, catastrophic injury expert Smyrna, CLCP certified smyrna ga, medical cost projections, life care plan smyrna ga, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/smyrna-ga-ga-life-care-planner.html" rel="canonical"/>
     <meta content="Smyrna Life Care Planner | GA Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Smyrna, XX - Life Care Planner",
+                "name": "Smyrna, GA - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/smyrna-ga-ga-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Smyrna Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Smyrna and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Smyrna and GA.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Smyrna, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Smyrna, GA - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through GA pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet GA court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>GA Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Smyrna, XX
+                                Serving Smyrna, GA
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Smyrna</h3>
                         <ul class="service-links">
-                            <li><a href="smyrna-ga-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="smyrna-ga-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="smyrna-ga-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="smyrna-ga-ga-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="smyrna-ga-ga-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="smyrna-ga-ga-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Smyrna, Georgia Coverage Area</h3>
-                        <p>In addition to Smyrna, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Smyrna, we serve attorneys throughout GA including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout GA and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/smyrna-ga-ga-vocational-expert.html
+++ b/locations/cities/smyrna-ga-ga-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Smyrna Vocational Expert | GA Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Smyrna. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Smyrna attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert smyrna ga, vocational expert XX, earning capacity expert smyrna ga, employability assessment Smyrna, expert witness vocational, litigation support smyrna ga, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert smyrna ga, vocational expert GA, earning capacity expert smyrna ga, employability assessment Smyrna, expert witness vocational, litigation support smyrna ga, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/smyrna-ga-ga-vocational-expert.html" rel="canonical"/>
     <meta content="Smyrna Vocational Expert | GA Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Smyrna, XX - Vocational Expert",
+                "name": "Smyrna, GA - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/smyrna-ga-ga-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Smyrna Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Smyrna and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Smyrna and GA.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Smyrna, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Smyrna, GA - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for GA family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Smyrna metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>GA vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Smyrna, XX
+                                Serving Smyrna, GA
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Smyrna</h3>
                         <ul class="service-links">
-                            <li><a href="smyrna-ga-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="smyrna-ga-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="smyrna-ga-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="smyrna-ga-ga-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="smyrna-ga-ga-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="smyrna-ga-ga-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Smyrna, Georgia Coverage Area</h3>
-                        <p>In addition to Smyrna, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Smyrna, we serve attorneys throughout GA including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout GA and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/smyrna-tn-tn-life-care-planner.html
+++ b/locations/cities/smyrna-tn-tn-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Smyrna Life Care Planner | TN Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Smyrna. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Smyrna attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner smyrna tn, life care planning XX, future medical costs smyrna tn, catastrophic injury expert Smyrna, CLCP certified smyrna tn, medical cost projections, life care plan smyrna tn, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner smyrna tn, life care planning TN, future medical costs smyrna tn, catastrophic injury expert Smyrna, CLCP certified smyrna tn, medical cost projections, life care plan smyrna tn, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/smyrna-tn-tn-life-care-planner.html" rel="canonical"/>
     <meta content="Smyrna Life Care Planner | TN Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Smyrna, XX - Life Care Planner",
+                "name": "Smyrna, TN - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/smyrna-tn-tn-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Smyrna Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Smyrna and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Smyrna and TN.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Smyrna, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Smyrna, TN - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through TN pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet TN court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>TN Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Smyrna, XX
+                                Serving Smyrna, TN
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Smyrna</h3>
                         <ul class="service-links">
-                            <li><a href="smyrna-tn-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="smyrna-tn-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="smyrna-tn-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="smyrna-tn-tn-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="smyrna-tn-tn-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="smyrna-tn-tn-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Smyrna, Tennessee Coverage Area</h3>
-                        <p>In addition to Smyrna, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Smyrna, we serve attorneys throughout TN including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout TN and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/smyrna-tn-tn-vocational-expert.html
+++ b/locations/cities/smyrna-tn-tn-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Smyrna Vocational Expert | TN Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Smyrna. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Smyrna attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert smyrna tn, vocational expert XX, earning capacity expert smyrna tn, employability assessment Smyrna, expert witness vocational, litigation support smyrna tn, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert smyrna tn, vocational expert TN, earning capacity expert smyrna tn, employability assessment Smyrna, expert witness vocational, litigation support smyrna tn, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/smyrna-tn-tn-vocational-expert.html" rel="canonical"/>
     <meta content="Smyrna Vocational Expert | TN Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Smyrna, XX - Vocational Expert",
+                "name": "Smyrna, TN - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/smyrna-tn-tn-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Smyrna Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Smyrna and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Smyrna and TN.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Smyrna, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Smyrna, TN - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for TN family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Smyrna metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>TN vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Smyrna, XX
+                                Serving Smyrna, TN
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Smyrna</h3>
                         <ul class="service-links">
-                            <li><a href="smyrna-tn-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="smyrna-tn-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="smyrna-tn-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="smyrna-tn-tn-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="smyrna-tn-tn-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="smyrna-tn-tn-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Smyrna, Tennessee Coverage Area</h3>
-                        <p>In addition to Smyrna, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Smyrna, we serve attorneys throughout TN including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout TN and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/springfield-oh-oh-life-care-planner.html
+++ b/locations/cities/springfield-oh-oh-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Springfield Life Care Planner | OH Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Springfield. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Springfield attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner springfield oh, life care planning XX, future medical costs springfield oh, catastrophic injury expert Springfield, CLCP certified springfield oh, medical cost projections, life care plan springfield oh, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner springfield oh, life care planning OH, future medical costs springfield oh, catastrophic injury expert Springfield, CLCP certified springfield oh, medical cost projections, life care plan springfield oh, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/springfield-oh-oh-life-care-planner.html" rel="canonical"/>
     <meta content="Springfield Life Care Planner | OH Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Springfield, XX - Life Care Planner",
+                "name": "Springfield, OH - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/springfield-oh-oh-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Springfield Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Springfield and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Springfield and OH.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Springfield, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Springfield, OH - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through OH pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet OH court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>OH Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Springfield, XX
+                                Serving Springfield, OH
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Springfield</h3>
                         <ul class="service-links">
-                            <li><a href="springfield-oh-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="springfield-oh-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="springfield-oh-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="springfield-oh-oh-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="springfield-oh-oh-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="springfield-oh-oh-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Springfield, Ohio Coverage Area</h3>
-                        <p>In addition to Springfield, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Springfield, we serve attorneys throughout OH including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout OH and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/springfield-oh-oh-vocational-expert.html
+++ b/locations/cities/springfield-oh-oh-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Springfield Vocational Expert | OH Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Springfield. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Springfield attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert springfield oh, vocational expert XX, earning capacity expert springfield oh, employability assessment Springfield, expert witness vocational, litigation support springfield oh, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert springfield oh, vocational expert OH, earning capacity expert springfield oh, employability assessment Springfield, expert witness vocational, litigation support springfield oh, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/springfield-oh-oh-vocational-expert.html" rel="canonical"/>
     <meta content="Springfield Vocational Expert | OH Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Springfield, XX - Vocational Expert",
+                "name": "Springfield, OH - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/springfield-oh-oh-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Springfield Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Springfield and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Springfield and OH.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Springfield, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Springfield, OH - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for OH family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Springfield metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>OH vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Springfield, XX
+                                Serving Springfield, OH
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Springfield</h3>
                         <ul class="service-links">
-                            <li><a href="springfield-oh-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="springfield-oh-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="springfield-oh-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="springfield-oh-oh-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="springfield-oh-oh-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="springfield-oh-oh-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Springfield, Ohio Coverage Area</h3>
-                        <p>In addition to Springfield, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Springfield, we serve attorneys throughout OH including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout OH and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/springfield-or-or-life-care-planner.html
+++ b/locations/cities/springfield-or-or-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Springfield Life Care Planner | OR Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Springfield. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Springfield attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner springfield or, life care planning XX, future medical costs springfield or, catastrophic injury expert Springfield, CLCP certified springfield or, medical cost projections, life care plan springfield or, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner springfield or, life care planning OR, future medical costs springfield or, catastrophic injury expert Springfield, CLCP certified springfield or, medical cost projections, life care plan springfield or, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/springfield-or-or-life-care-planner.html" rel="canonical"/>
     <meta content="Springfield Life Care Planner | OR Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Springfield, XX - Life Care Planner",
+                "name": "Springfield, OR - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/springfield-or-or-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Springfield Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Springfield and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Springfield and OR.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Springfield, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Springfield, OR - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through OR pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet OR court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>OR Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Springfield, XX
+                                Serving Springfield, OR
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Springfield</h3>
                         <ul class="service-links">
-                            <li><a href="springfield-or-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="springfield-or-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="springfield-or-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="springfield-or-or-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="springfield-or-or-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="springfield-or-or-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Springfield, Oregon Coverage Area</h3>
-                        <p>In addition to Springfield, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Springfield, we serve attorneys throughout OR including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout OR and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/springfield-or-or-vocational-expert.html
+++ b/locations/cities/springfield-or-or-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Springfield Vocational Expert | OR Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Springfield. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Springfield attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert springfield or, vocational expert XX, earning capacity expert springfield or, employability assessment Springfield, expert witness vocational, litigation support springfield or, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert springfield or, vocational expert OR, earning capacity expert springfield or, employability assessment Springfield, expert witness vocational, litigation support springfield or, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/springfield-or-or-vocational-expert.html" rel="canonical"/>
     <meta content="Springfield Vocational Expert | OR Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Springfield, XX - Vocational Expert",
+                "name": "Springfield, OR - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/springfield-or-or-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Springfield Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Springfield and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Springfield and OR.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Springfield, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Springfield, OR - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for OR family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Springfield metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>OR vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Springfield, XX
+                                Serving Springfield, OR
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Springfield</h3>
                         <ul class="service-links">
-                            <li><a href="springfield-or-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="springfield-or-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="springfield-or-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="springfield-or-or-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="springfield-or-or-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="springfield-or-or-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Springfield, Oregon Coverage Area</h3>
-                        <p>In addition to Springfield, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Springfield, we serve attorneys throughout OR including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout OR and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/st-albans-wv-wv-life-care-planner.html
+++ b/locations/cities/st-albans-wv-wv-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>St. Albans Life Care Planner | WV Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in St. Albans. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving St. Albans attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner st albans wv, life care planning XX, future medical costs st albans wv, catastrophic injury expert St. Albans, CLCP certified st albans wv, medical cost projections, life care plan st albans wv, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner st albans wv, life care planning WV, future medical costs st albans wv, catastrophic injury expert St. Albans, CLCP certified st albans wv, medical cost projections, life care plan st albans wv, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/st-albans-wv-wv-life-care-planner.html" rel="canonical"/>
     <meta content="St. Albans Life Care Planner | WV Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "St. Albans, XX - Life Care Planner",
+                "name": "St. Albans, WV - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/st-albans-wv-wv-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>St. Albans Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout St. Albans and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout St. Albans and WV.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">St. Albans, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">St. Albans, WV - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through WV pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet WV court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>WV Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving St. Albans, XX
+                                Serving St. Albans, WV
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in St. Albans</h3>
                         <ul class="service-links">
-                            <li><a href="st-albans-wv-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="st-albans-wv-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="st-albans-wv-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="st-albans-wv-wv-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="st-albans-wv-wv-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="st-albans-wv-wv-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>St Albans, West Virginia Coverage Area</h3>
-                        <p>In addition to St. Albans, we serve attorneys throughout XX including:</p>
+                        <p>In addition to St. Albans, we serve attorneys throughout WV including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout WV and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/st-albans-wv-wv-vocational-expert.html
+++ b/locations/cities/st-albans-wv-wv-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>St. Albans Vocational Expert | WV Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in St. Albans. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for St. Albans attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert st albans wv, vocational expert XX, earning capacity expert st albans wv, employability assessment St. Albans, expert witness vocational, litigation support st albans wv, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert st albans wv, vocational expert WV, earning capacity expert st albans wv, employability assessment St. Albans, expert witness vocational, litigation support st albans wv, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/st-albans-wv-wv-vocational-expert.html" rel="canonical"/>
     <meta content="St. Albans Vocational Expert | WV Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "St. Albans, XX - Vocational Expert",
+                "name": "St. Albans, WV - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/st-albans-wv-wv-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>St. Albans Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout St. Albans and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout St. Albans and WV.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">St. Albans, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">St. Albans, WV - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for WV family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the St. Albans metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>WV vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving St. Albans, XX
+                                Serving St. Albans, WV
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in St. Albans</h3>
                         <ul class="service-links">
-                            <li><a href="st-albans-wv-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="st-albans-wv-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="st-albans-wv-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="st-albans-wv-wv-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="st-albans-wv-wv-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="st-albans-wv-wv-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>St Albans, West Virginia Coverage Area</h3>
-                        <p>In addition to St. Albans, we serve attorneys throughout XX including:</p>
+                        <p>In addition to St. Albans, we serve attorneys throughout WV including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout WV and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/troy-ny-ny-life-care-planner.html
+++ b/locations/cities/troy-ny-ny-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Troy Life Care Planner | NY Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Troy. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Troy attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner troy ny, life care planning XX, future medical costs troy ny, catastrophic injury expert Troy, CLCP certified troy ny, medical cost projections, life care plan troy ny, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner troy ny, life care planning NY, future medical costs troy ny, catastrophic injury expert Troy, CLCP certified troy ny, medical cost projections, life care plan troy ny, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/troy-ny-ny-life-care-planner.html" rel="canonical"/>
     <meta content="Troy Life Care Planner | NY Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Troy, XX - Life Care Planner",
+                "name": "Troy, NY - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/troy-ny-ny-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Troy Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Troy and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Troy and NY.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Troy, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Troy, NY - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through NY pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet NY court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>NY Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Troy, XX
+                                Serving Troy, NY
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Troy</h3>
                         <ul class="service-links">
-                            <li><a href="troy-ny-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="troy-ny-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="troy-ny-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="troy-ny-ny-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="troy-ny-ny-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="troy-ny-ny-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Troy, New York Coverage Area</h3>
-                        <p>In addition to Troy, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Troy, we serve attorneys throughout NY including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout NY and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/troy-ny-ny-vocational-expert.html
+++ b/locations/cities/troy-ny-ny-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Troy Vocational Expert | NY Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Troy. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Troy attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert troy ny, vocational expert XX, earning capacity expert troy ny, employability assessment Troy, expert witness vocational, litigation support troy ny, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert troy ny, vocational expert NY, earning capacity expert troy ny, employability assessment Troy, expert witness vocational, litigation support troy ny, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/troy-ny-ny-vocational-expert.html" rel="canonical"/>
     <meta content="Troy Vocational Expert | NY Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Troy, XX - Vocational Expert",
+                "name": "Troy, NY - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/troy-ny-ny-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Troy Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Troy and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Troy and NY.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Troy, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Troy, NY - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for NY family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Troy metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>NY vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Troy, XX
+                                Serving Troy, NY
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Troy</h3>
                         <ul class="service-links">
-                            <li><a href="troy-ny-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="troy-ny-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="troy-ny-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="troy-ny-ny-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="troy-ny-ny-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="troy-ny-ny-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Troy, New York Coverage Area</h3>
-                        <p>In addition to Troy, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Troy, we serve attorneys throughout NY including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout NY and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/wilmington-de-de-life-care-planner.html
+++ b/locations/cities/wilmington-de-de-life-care-planner.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Wilmington Life Care Planner | DE Future Medical Cost Expert | CLCP | Skerritt Economics</title>
     <meta content="CLCP-life care planner in Wilmington. Expert future medical cost projections and comprehensive care planning for catastrophic injury cases. Serving Wilmington attorneys with court-tested life care plans." name="description"/>
-    <meta content="life care planner wilmington de, life care planning XX, future medical costs wilmington de, catastrophic injury expert Wilmington, CLCP certified wilmington de, medical cost projections, life care plan wilmington de, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
+    <meta content="life care planner wilmington de, life care planning DE, future medical costs wilmington de, catastrophic injury expert Wilmington, CLCP certified wilmington de, medical cost projections, life care plan wilmington de, future care needs, medical expert witness, rehabilitation planning" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/wilmington-de-de-life-care-planner.html" rel="canonical"/>
     <meta content="Wilmington Life Care Planner | DE Future Medical Cost Expert | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Wilmington, XX - Life Care Planner",
+                "name": "Wilmington, DE - Life Care Planner",
                 "item": "https://skerritteconomics.com/locations/cities/wilmington-de-de-life-care-planner.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Wilmington Life Care Planning Services</h1>
-            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Wilmington and XX.</p>
+            <p>CLCP-life care planner providing future medical cost projections and care planning for catastrophic injury cases throughout Wilmington and DE.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Wilmington, XX - Life Care Planner</span>
+                    <span class="breadcrumb-current">Wilmington, DE - Life Care Planner</span>
                 </li>
             </ol>
         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Birth Injuries & Cerebral Palsy</h3>
-                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through XX pediatric and adult services.</p>
+                                <p>Lifetime care planning for developmental therapies, special education, adaptive equipment, and transitional care through DE pediatric and adult services.</p>
                             </div>
                             <div class="practice-item">
                                 <h3>Burn & Amputation Injuries</h3>
@@ -321,7 +321,7 @@
                     <!-- Methodology -->
                     <section class="methodology-section">
                         <h2>Life Care Planning Methodology</h2>
-                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet XX court standards:</p>
+                        <p>Our CLCP-certified approach ensures comprehensive and life care plans that meet DE court standards:</p>
                         <ul class="methodology-list">
                             <li><strong>Medical Record Review:</strong> Thorough analysis of all medical documentation and prognosis</li>
                             <li><strong>Physician Collaboration:</strong> Consultation with treating physicians and medical specialists</li>
@@ -340,7 +340,7 @@
                             <li>Rehabilitation facilities and therapy providers</li>
                             <li>Home health agencies and nursing services</li>
                             <li>Medical equipment suppliers and pharmacies</li>
-                            <li>XX Medicaid and insurance considerations</li>
+                            <li>DE Medicaid and insurance considerations</li>
                         </ul>
                     </section>
                     
@@ -374,7 +374,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Wilmington, XX
+                                Serving Wilmington, DE
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -384,9 +384,9 @@
                     <div class="related-services">
                         <h3>Related Services in Wilmington</h3>
                         <ul class="service-links">
-                            <li><a href="wilmington-de-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="wilmington-de-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="wilmington-de-xx-vocational-expert.html">Vocational Expert</a></li>
+                            <li><a href="wilmington-de-de-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="wilmington-de-de-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="wilmington-de-de-vocational-expert.html">Vocational Expert</a></li>
                         </ul>
                     </div>
                     
@@ -406,7 +406,7 @@
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Wilmington, Delaware Coverage Area</h3>
-                        <p>In addition to Wilmington, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Wilmington, we serve attorneys throughout DE including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -422,7 +422,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert life care planning and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert life care planning and forensic economics services for legal professionals throughout DE and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>

--- a/locations/cities/wilmington-de-de-vocational-expert.html
+++ b/locations/cities/wilmington-de-de-vocational-expert.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Wilmington Vocational Expert | DE Earning Capacity Analysis | Court-Qualified | Skerritt Economics</title>
     <meta content="experienced vocational expert in Wilmington. Expert earning capacity analysis, employability assessments, and vocational rehabilitation planning for Wilmington attorneys. CRC-certified expert witness with extensive federal and state court experience." name="description"/>
-    <meta content="vocational expert wilmington de, vocational expert XX, earning capacity expert wilmington de, employability assessment Wilmington, expert witness vocational, litigation support wilmington de, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
+    <meta content="vocational expert wilmington de, vocational expert DE, earning capacity expert wilmington de, employability assessment Wilmington, expert witness vocational, litigation support wilmington de, disability evaluation, vocational rehabilitation, labor market analysis, wage loss calculations" name="keywords"/>
     <link href="../../favicon.ico" rel="icon" type="image/x-icon"/>
     <link href="https://skerritteconomics.com/locations/cities/wilmington-de-de-vocational-expert.html" rel="canonical"/>
     <meta content="Wilmington Vocational Expert | DE Earning Capacity Analysis | Skerritt Economics" property="og:title"/>
@@ -94,7 +94,7 @@
             {
                 "@type": "ListItem",
                 "position": 3,
-                "name": "Wilmington, XX - Vocational Expert",
+                "name": "Wilmington, DE - Vocational Expert",
                 "item": "https://skerritteconomics.com/locations/cities/wilmington-de-de-vocational-expert.html"
             }
         ]
@@ -219,7 +219,7 @@
     <section class="hero-section">
         <div class="container hero-content">
             <h1>Wilmington Vocational Expert Services</h1>
-            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Wilmington and XX.</p>
+            <p>CRC-certified vocational expert providing comprehensive earning capacity analysis, employability assessments, and vocational rehabilitation planning for attorneys throughout Wilmington and DE.</p>
             <div class="location-badges">
                 <span class="badge">
                     <i class="icon icon-location"></i>
@@ -248,7 +248,7 @@
                     <a class="breadcrumb-link" href="../../locations/">Locations</a>
                 </li>
                 <li class="breadcrumb-item">
-                    <span class="breadcrumb-current">Wilmington, XX - Vocational Expert</span>
+                    <span class="breadcrumb-current">Wilmington, DE - Vocational Expert</span>
                 </li>
             </ol>
         </div>
@@ -313,7 +313,7 @@
                             </div>
                             <div class="practice-item">
                                 <h3>Family Law & Divorce</h3>
-                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for XX family court proceedings.</p>
+                                <p>Determine earning capacity for support calculations, evaluate vocational rehabilitation needs, and assess employment potential for DE family court proceedings.</p>
                             </div>
                         </div>
                     </section>
@@ -326,7 +326,7 @@
                             <li>Major employers and industries in the Wilmington metropolitan area</li>
                             <li>Local wage scales and compensation trends</li>
                             <li>Regional education and training resources</li>
-                            <li>XX vocational rehabilitation services and programs</li>
+                            <li>DE vocational rehabilitation services and programs</li>
                             <li>Area-specific job availability and placement rates</li>
                         </ul>
                     </section>
@@ -361,7 +361,7 @@
                             </li>
                             <li>
                                 <i class="icon icon-location"></i>
-                                Serving Wilmington, XX
+                                Serving Wilmington, DE
                             </li>
                         </ul>
                         <a href="../../contact/" class="btn btn-primary btn-block">Get Started</a>
@@ -371,16 +371,16 @@
                     <div class="related-services">
                         <h3>Related Services in Wilmington</h3>
                         <ul class="service-links">
-                            <li><a href="wilmington-de-xx-forensic-economist.html">Forensic Economics</a></li>
-                            <li><a href="wilmington-de-xx-business-valuation-analyst.html">Business Valuation</a></li>
-                            <li><a href="wilmington-de-xx-life-care-planner.html">Life Care Planning</a></li>
+                            <li><a href="wilmington-de-de-forensic-economist.html">Forensic Economics</a></li>
+                            <li><a href="wilmington-de-de-business-valuation-analyst.html">Business Valuation</a></li>
+                            <li><a href="wilmington-de-de-life-care-planner.html">Life Care Planning</a></li>
                         </ul>
                     </div>
                     
                     <!-- Coverage Area -->
                     <div class="coverage-area">
                         <h3>Wilmington, Delaware Coverage Area</h3>
-                        <p>In addition to Wilmington, we serve attorneys throughout XX including:</p>
+                        <p>In addition to Wilmington, we serve attorneys throughout DE including:</p>
                         <ul class="city-list">
                             <li>Statewide coverage available</li>
                         </ul>
@@ -396,7 +396,7 @@
             <div class="footer-grid">
                 <div class="footer-col">
                     <h4>Skerritt Economics &amp; Consulting</h4>
-                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout XX and nationwide.</p>
+                    <p>Expert vocational assessment and forensic economics services for legal professionals throughout DE and nationwide.</p>
                     <p class="footer-contact">
                         400 Putnam Pike Ste J<br/>
                         Smithfield, RI 02917<br/>


### PR DESCRIPTION
## Summary
- Fixed 135 XX placeholders across 16 location pages
- Replaced XX with correct state codes based on city/state in filenames
- Ensures consistent and accurate state references throughout the site

## Changes Made
Replaced XX placeholders with correct state codes in the following files:
- **Columbus, GA** (2 files) - replaced XX with GA
- **Smyrna, GA** (2 files) - replaced XX with GA  
- **Smyrna, TN** (2 files) - replaced XX with TN
- **Springfield, OH** (2 files) - replaced XX with OH
- **Springfield, OR** (2 files) - replaced XX with OR
- **St. Albans, WV** (2 files) - replaced XX with WV
- **Troy, NY** (2 files) - replaced XX with NY
- **Wilmington, DE** (2 files) - replaced XX with DE

## Test Plan
- [x] Ran placeholder check script to identify all XX placeholders
- [x] Fixed all 135 occurrences across 16 files
- [x] Verified no XX placeholders remain in location pages
- [ ] Review HTML pages to ensure correct state codes display
- [ ] Check that all links and references work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)