### PR TITLE
fix: prevent nav from covering top content

### DIFF
--- a/_includes/head-optimized.html
+++ b/_includes/head-optimized.html
@@ -133,8 +133,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;l
 .container{width:100%;max-width:var(--max-width);margin:0 auto;padding:0 1rem}
 
 /* Mobile Navigation */
-.main-nav{background:var(--background);box-shadow:0 1px 3px rgba(0,0,0,0.1);position:fixed;top:0;left:0;right:0;z-index:9999;height:60px}
-body{padding-top:60px}
+.main-nav{background:var(--background);box-shadow:0 1px 3px rgba(0,0,0,0.1);position:sticky;top:0;left:0;right:0;z-index:9999;height:60px}
+main{padding-top:80px}
 .nav-wrapper{display:flex;justify-content:space-between;align-items:center;height:100%;padding:0 1rem}
 .logo{font-size:1.125rem;font-weight:700;color:var(--dark-text);text-decoration:none}
 .logo span{display:none}
@@ -146,7 +146,7 @@ body{padding-top:60px}
 /* Force hide TOC on mobile */
 @media (max-width: 768px) {
   .toc,.toc__menu,.toc__title,.sidebar__right,.sidebar,nav.toc,aside.sidebar__right,[class*="toc"],[class*="table-of-contents"],[id*="toc"],.mobile-toc,.table-of-contents{display:none!important;visibility:hidden!important;width:0!important;height:0!important;overflow:hidden!important;position:absolute!important;left:-9999px!important}
-  body{padding-top:80px!important}
+  main{padding-top:80px!important}
   main>*:first-child{padding-top:20px!important}
 }
 
@@ -184,6 +184,7 @@ p{margin-bottom:1rem}
 @media (min-width:768px){
   .container{padding:0 2rem}
   .main-nav{position:sticky;top:0;height:auto}
+  main{padding-top:0}
   body{padding-top:0}
   .nav-wrapper{padding:1rem 0}
   .logo{font-size:1.25rem}
@@ -214,6 +215,7 @@ p{margin-bottom:1rem}
 /* Prevent Layout Shift */
 .loading-placeholder{min-height:100vh;background:var(--background)}
 img{max-width:100%;height:auto}
+@media print{.main-nav{position:static!important}}
 </style>
 
 <!-- Load CSS asynchronously with priority -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,8 +27,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;l
 .container{width:100%;max-width:var(--max-width);margin:0 auto;padding:0 1rem}
 
 /* Mobile Navigation */
-.main-nav{background:var(--background);box-shadow:0 1px 3px rgba(0,0,0,0.1);position:fixed;top:0;left:0;right:0;z-index:9999;height:60px}
-body{padding-top:60px}
+.main-nav{background:var(--background);box-shadow:0 1px 3px rgba(0,0,0,0.1);position:sticky;top:0;left:0;right:0;z-index:9999;height:60px}
+main{padding-top:80px}
 .nav-wrapper{display:flex;justify-content:space-between;align-items:center;height:100%;padding:0 1rem}
 .logo{font-size:1.125rem;font-weight:700;color:var(--dark-text);text-decoration:none}
 .logo span{display:none}
@@ -40,7 +40,7 @@ body{padding-top:60px}
 /* Force hide TOC on mobile */
 @media (max-width: 768px) {
   .toc,.toc__menu,.toc__title,.sidebar__right,.sidebar,nav.toc,aside.sidebar__right,[class*="toc"],[class*="table-of-contents"],[id*="toc"],.mobile-toc,.table-of-contents{display:none!important;visibility:hidden!important;width:0!important;height:0!important;overflow:hidden!important;position:absolute!important;left:-9999px!important}
-  body{padding-top:80px!important}
+  main{padding-top:80px!important}
   main>*:first-child{padding-top:20px!important}
 }
 
@@ -78,6 +78,7 @@ p{margin-bottom:1rem}
 @media (min-width:768px){
   .container{padding:0 2rem}
   .main-nav{position:sticky;top:0;height:auto}
+  main{padding-top:0}
   body{padding-top:0}
   .nav-wrapper{padding:1rem 0}
   .logo{font-size:1.25rem}
@@ -108,6 +109,7 @@ p{margin-bottom:1rem}
 /* Prevent Layout Shift */
 .loading-placeholder{min-height:100vh;background:var(--background)}
 img{max-width:100%;height:auto}
+@media print{.main-nav{position:static!important}}
 </style>
 
 <!-- Load CSS asynchronously with priority -->

--- a/css/mobile-complete-fix.css
+++ b/css/mobile-complete-fix.css
@@ -19,8 +19,16 @@
         padding: 0;
     }
     
-    /* Fix body padding for fixed nav - INCREASED FOR MORE SPACE */
+    /* Offset main content for sticky header */
+    .main-nav {
+        position: sticky !important;
+        top: 0;
+        z-index: 1000;
+    }
     body {
+        padding-top: 0 !important;
+    }
+    main {
         padding-top: 80px !important;
     }
     
@@ -121,14 +129,14 @@
     /* Ensure main content starts below nav */
     main {
         margin-top: 0 !important;
-        padding-top: 0 !important;
+        padding-top: 80px !important;
         width: 100% !important;
     }
-    
-    /* First child of main gets extra padding */
+
+    /* First child of main should not add extra padding */
     main > *:first-child {
         margin-top: 0 !important;
-        padding-top: 1rem !important;
+        padding-top: 0 !important;
     }
     
     /* Ensure page content takes full width */
@@ -228,6 +236,12 @@
     .practice-chip .icon {
         margin-right: 0.5rem !important;
         font-size: 1.1rem !important;
+    }
+}
+
+@media print {
+    .main-nav {
+        position: static !important;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure main nav uses sticky positioning and add top padding so content isn't hidden under the header
- reset spacing on larger screens
- disable sticky nav in print styles to avoid overlap when printing

## Testing
- `bundle exec jekyll build` *(fails: cannot load such file -- csv)*

------
https://chatgpt.com/codex/tasks/task_e_688e733f49e8832fb3a45dba2d7fdeb4

## Summary by Sourcery

Ensure the main navigation uses sticky positioning without overlapping content by shifting spacing from body to main, normalizing padding across breakpoints, and disabling sticky behavior in print.

Bug Fixes:
- Prevent navigation bar from covering top content by offsetting main content
- Disable sticky navigation in print styles to avoid overlap when printing

Enhancements:
- Change navigation positioning from fixed to sticky and adjust z-index
- Move top padding from body to main element and remove extra first-child padding
- Reset main padding on larger screens to restore default layout