### PR TITLE
Simplify navigation to match tools page layout

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -18,7 +18,6 @@
   <ul class="dropdown">
   <li><a href="{{ '/services/forensic-economics/' | relative_url }}">Forensic Economics</a></li>
   <li><a href="{{ '/services/business-valuation/' | relative_url }}">Business Valuation</a></li>
-  <li><a href="{{ '/services/business-consulting/' | relative_url }}">Business Consulting</a></li>
   </ul>
   </li>
   <li class="has-dropdown">

--- a/css/styles.css
+++ b/css/styles.css
@@ -1562,6 +1562,11 @@ a:hover {
     align-items: center;
     gap: 1.5rem;
     flex-wrap: nowrap;
+    flex-grow: 1;
+}
+
+.nav-menu > li:last-child {
+    margin-left: auto;
 }
 
 .nav-menu a {
@@ -3822,36 +3827,19 @@ textarea.success {
     }
 }/* Navigation Responsive Adjustments - Fixed to prevent cutoff */
 
-/* Critical fix for navigation at medium screen sizes */
-@media (min-width: 769px) and (max-width: 1350px) {
-    .logo {
-        font-size: 1.1rem;
-        flex-shrink: 0;
-    }
-    
-    .logo span {
-        font-size: 0.9rem; /* Make "& Consulting" smaller instead of hiding */
-    }
-    
+/* Desktop navigation optimal spacing */
+@media (min-width: 1024px) {
     .nav-menu {
-        gap: 0.5rem;
+        gap: 1.75rem;
     }
     
     .nav-menu a {
-        font-size: 0.825rem;
-        padding: 0.4rem 0.35rem;
-        white-space: nowrap;
+        font-size: 0.95rem;
+        padding: 0.5rem 0.75rem;
     }
     
     .nav-cta {
-        margin-left: 0.35rem;
-        padding: 0.5rem 0.9rem !important;
-        font-size: 0.825rem;
-    }
-    
-    .container {
-        max-width: 100%;
-        padding: 0 20px;
+        padding: 0.625rem 1.25rem !important;
     }
 }
 


### PR DESCRIPTION
## Summary
Updated the navigation bar to match the cleaner layout used on the tools page, with Contact button properly positioned in the right corner.

## Changes Made
- **Simplified navigation structure** to match tools page layout exactly
- **Removed Business Consulting** from Services dropdown (now only Forensic Economics and Business Valuation)
- **Kept all main navigation items visible**: Home, Services, Practice Areas, Case Studies, About, Resources, Blog, Tools
- **Contact button stays in right corner** using `margin-left: auto` CSS
- **Improved spacing** with better gap management between items

## CSS Updates
- Added `flex-grow: 1` to nav-menu for proper space distribution
- Added `margin-left: auto` to last nav item (Contact) to push it to the right
- Optimized responsive breakpoints for better desktop display

## Result
Navigation now matches the professional, clean layout of the tools page with Contact button properly positioned in the right corner.

🤖 Generated with [Claude Code](https://claude.ai/code)