### PR TITLE
Load mobile header fixes stylesheet

### DIFF
--- a/_includes/performance-optimizations.html
+++ b/_includes/performance-optimizations.html
@@ -165,6 +165,9 @@ img {
 <link rel="preload" href="{{ '/css/styles.min.css' | relative_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="{{ '/css/styles.min.css' | relative_url }}"></noscript>
 
+<link rel="preload" href="{{ '/css/mobile-fixes.min.css' | relative_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="{{ '/css/mobile-fixes.min.css' | relative_url }}"></noscript>
+
 <!-- JavaScript Loading Strategy -->
 <script>
 // Load non-critical JavaScript after page load


### PR DESCRIPTION
## Summary
- load mobile-fixes stylesheet so navigation stays fixed and spaced correctly on phones

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: undefined method `untaint` for String)*
- `python3 minify_assets.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68900d243370832f862deed54fa176b5

## Summary by Sourcery

New Features:
- Preload and apply a mobile-fixes stylesheet to keep mobile navigation fixed and spaced correctly