### PR TITLE
Improve mobile header padding across devices

### DIFF
--- a/css/mobile-theme-fixes.css
+++ b/css/mobile-theme-fixes.css
@@ -7,13 +7,17 @@
 
 /* Fix top spacing for all pages on mobile */
 @media (max-width: 768px) {
+    :root {
+        --mobile-nav-height: 60px;
+    }
+
     /* Remove any negative margins and add proper spacing */
     body {
-        padding-top: 70px !important; /* Account for fixed navigation */
+        padding-top: calc(var(--mobile-nav-height) + env(safe-area-inset-top)) !important;
         margin: 0;
         overflow-x: hidden;
     }
-    
+
     /* Fix main navigation */
     .main-nav {
         position: fixed !important;
@@ -21,7 +25,8 @@
         left: 0;
         right: 0;
         z-index: 9999;
-        height: 60px;
+        height: calc(var(--mobile-nav-height) + env(safe-area-inset-top));
+        padding-top: env(safe-area-inset-top);
         background: white;
         box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }

--- a/js/main.js
+++ b/js/main.js
@@ -2,11 +2,21 @@
 document.addEventListener('DOMContentLoaded', function() {
     const mobileMenuToggle = document.querySelector('.mobile-menu-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    
+    const nav = document.querySelector('.main-nav');
+
     // Create mobile navigation overlay
     const mobileNavOverlay = document.createElement('div');
     mobileNavOverlay.className = 'mobile-nav-overlay';
     document.body.appendChild(mobileNavOverlay);
+
+    // Ensure content isn't hidden behind the fixed header
+    function setBodyPadding() {
+        if (nav) {
+            document.body.style.paddingTop = nav.offsetHeight + 'px';
+        }
+    }
+    setBodyPadding();
+    window.addEventListener('resize', setBodyPadding);
     
     if (mobileMenuToggle && navMenu) {
         mobileMenuToggle.addEventListener('click', function() {
@@ -88,7 +98,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Add scroll effect to navigation with debouncing
     let lastScrollTop = 0;
-    const nav = document.querySelector('.main-nav');
     let ticking = false;
     
     function updateNavOnScroll() {


### PR DESCRIPTION
## Summary
- ensure mobile header respects device safe areas using CSS variables
- dynamically pad body to header height so content isn't obscured

## Testing
- `node --check js/main.js`
- `bundle exec jekyll build --quiet` *(fails: "bundler: command not found: jekyll"; attempted `bundle install` but bundler 1.17.2 raises `undefined method 'untaint'`)*

------
https://chatgpt.com/codex/tasks/task_e_6890b30df078832fb4dcf6943d87b440

## Summary by Sourcery

Use CSS variables and safe-area-inset-top to improve mobile header spacing and introduce dynamic JS body padding to prevent content from being obscured by the fixed header.

Enhancements:
- Define --mobile-nav-height and leverage env(safe-area-inset-top) in mobile CSS to set header height and body padding dynamically
- Introduce setBodyPadding function in main.js to adjust body padding-top based on the actual header height on page load and window resize
- Remove redundant main-nav element lookup in the scroll effect logic