### PR TITLE
Fix home page dropdown menus for mobile and keyboard use

### DIFF
--- a/css/homepage.css
+++ b/css/homepage.css
@@ -18,7 +18,9 @@ body * {
     visibility: hidden !important;
 }
 
-.has-dropdown:hover .dropdown {
+.has-dropdown:hover .dropdown,
+.has-dropdown:focus-within .dropdown,
+.has-dropdown.open .dropdown {
     display: block !important;
     opacity: 1 !important;
     visibility: visible !important;
@@ -681,7 +683,9 @@ a:hover {
     position: relative;
 }
 
-.has-dropdown:hover .dropdown {
+.has-dropdown:hover .dropdown,
+.has-dropdown:focus-within .dropdown,
+.has-dropdown.open .dropdown {
     display: block !important;
     opacity: 1 !important;
     visibility: visible !important;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1519,11 +1519,14 @@ a:hover {
     display: none !important;
 }
 
-.has-dropdown:hover .dropdown {
+.has-dropdown:hover .dropdown,
+.has-dropdown:focus-within .dropdown,
+.has-dropdown.open .dropdown {
     opacity: 1 !important;
     visibility: visible !important;
     transform: translateY(0);
     display: block !important;
+    pointer-events: auto;
 }
 
 .dropdown li {
@@ -2824,7 +2827,11 @@ ul.dropdown {
 }
 
 .nav-menu .has-dropdown:hover .dropdown,
-.main-nav .has-dropdown:hover .dropdown {
+.nav-menu .has-dropdown:focus-within .dropdown,
+.nav-menu .has-dropdown.open .dropdown,
+.main-nav .has-dropdown:hover .dropdown,
+.main-nav .has-dropdown:focus-within .dropdown,
+.main-nav .has-dropdown.open .dropdown {
     opacity: 1 !important;
     visibility: visible !important;
     transform: translateY(0);

--- a/js/main.js
+++ b/js/main.js
@@ -17,14 +17,43 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Close mobile menu when clicking on a link
+    // Close mobile menu or toggle dropdowns when clicking on navigation links
     const navLinks = document.querySelectorAll('.nav-menu a');
+    const dropdownParents = document.querySelectorAll('.nav-menu .has-dropdown');
     navLinks.forEach(link => {
-        link.addEventListener('click', function() {
+        link.addEventListener('click', function(e) {
+            const parentLi = link.parentElement;
+            if (parentLi && parentLi.classList.contains('has-dropdown')) {
+                if (!parentLi.classList.contains('open')) {
+                    e.preventDefault();
+                    dropdownParents.forEach(item => {
+                        if (item !== parentLi) item.classList.remove('open');
+                    });
+                    parentLi.classList.add('open');
+                } else {
+                    if (navMenu) navMenu.classList.remove('active');
+                    if (mobileNavOverlay) mobileNavOverlay.classList.remove('active');
+                    if (mobileMenuToggle) mobileMenuToggle.classList.remove('active');
+                    document.body.classList.remove('menu-open');
+                }
+                return;
+            }
             if (navMenu) navMenu.classList.remove('active');
             if (mobileNavOverlay) mobileNavOverlay.classList.remove('active');
             if (mobileMenuToggle) mobileMenuToggle.classList.remove('active');
             document.body.classList.remove('menu-open');
+        });
+
+        // Keyboard accessibility for dropdowns
+        link.addEventListener('keydown', function(e) {
+            const parentLi = link.parentElement;
+            if ((e.key === 'Enter' || e.key === ' ') && parentLi && parentLi.classList.contains('has-dropdown')) {
+                e.preventDefault();
+                dropdownParents.forEach(item => {
+                    if (item !== parentLi) item.classList.remove('open');
+                });
+                parentLi.classList.toggle('open');
+            }
         });
     });
 
@@ -44,6 +73,15 @@ document.addEventListener('DOMContentLoaded', function() {
             mobileMenuToggle.classList.remove('active');
             document.body.classList.remove('menu-open');
         }
+    });
+
+    // Close any open dropdowns when clicking outside
+    document.addEventListener('click', function(e) {
+        dropdownParents.forEach(item => {
+            if (!item.contains(e.target)) {
+                item.classList.remove('open');
+            }
+        });
     });
 
     // Smooth scrolling for anchor links


### PR DESCRIPTION
## Summary
- Allow dropdown menus to open on click and via keyboard
- Expose dropdowns when parent has focus or explicit open class

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `npm test` *(fails: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68967bc2faec832f97341c364058733d

## Summary by Sourcery

Improve dropdown menu accessibility and behavior on mobile and keyboard interactions

Enhancements:
- Enable dropdown menus to open and close on click within the navigation
- Implement keyboard support to toggle dropdowns via Enter and Space keys
- Automatically close any open dropdown when clicking outside the menu
- Update CSS to show dropdowns on focus-within and when an explicit open class is set, including pointer-events support